### PR TITLE
Read port from env

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ cd EIS
 chmod +x ./eis
 chmod +x install.sh
 sudo ./install.sh  
-nohup ./eis &
+PORT=8080 nohup ./eis &
 ```
 
 Open http://\<your-ip\>:8080

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"github.com/kataras/iris/v12"
 	"github.com/kataras/iris/v12/websocket"
 	"log"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -17,6 +18,12 @@ var messageChan = make(chan string)
 var conns []*websocket.Conn
 
 func main() {
+	// Read port from environment variable, default to 8080 if not set
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+
 	getConfig()
 
 	ws := websocket.New(websocket.DefaultGorillaUpgrader, websocket.Events{
@@ -60,7 +67,7 @@ func main() {
 
 	app.HandleDir("/static", iris.Dir("./static"))
 
-	app.Listen(":8080")
+	app.Listen(":" + port)
 }
 
 func home(ctx iris.Context) {


### PR DESCRIPTION
## Description:
This PR modifies the application to read the port number from an environment variable (PORT) instead of hardcoding it. This allows for more flexibility when deploying the application in different environments. If PORT is not set, it defaults to 8080 (or any other reasonable fallback).

## Changes:
- Updated code to read PORT from the environment.
- Set a default value (8080) if the variable is not defined.
- Updated documentation to reflect the new behavior.